### PR TITLE
Fix 64-bit mingw build

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -595,7 +595,7 @@ $(objdir)cpu/m68k/m68kops.o: $(objdir)cpu/m68k/m68kmake.exe $(objdir)dep/generat
 	@echo Compiling Musashi MC680x0 core \(m68kops.c\)...
 	@$(CC) $(CFLAGS) -c $(objdir)dep/generated/m68kops.c -o $(objdir)cpu/m68k/m68kops.o
 
-$(objdir)dep/generated/m68kops.h: $(objdir)cpu/m68k/m68kmake.exe $(srcdir)cpu/m68k/m68k_in.c
+$(objdir)dep/generated/m68kops.h $(objdir)dep/generated/m68kops.c: $(objdir)cpu/m68k/m68kmake.exe $(srcdir)cpu/m68k/m68k_in.c
 	$(objdir)/cpu/m68k/m68kmake $(objdir)dep/generated/ $(srcdir)cpu/m68k/m68k_in.c
 
 $(objdir)cpu/m68k/m68kmake.exe: $(srcdir)cpu/m68k/m68kmake.c


### PR DESCRIPTION
Due to a race condition, `m64make.exe` did not run causing make to complain about missing `m68kops.c`. I did not check the other makefiles but the condition might be present there too.

Make invocation `make mingw510 -j5 BUILD_X64_EXE=1`
Make version `GNU Make 4.2.1`