### PR TITLE
Qsound: minor cleanups

### DIFF
--- a/src/burn/drv/capcom/cps.h
+++ b/src/burn/drv/capcom/cps.h
@@ -261,7 +261,6 @@ extern INT32 Cawingb;
 extern INT32 Wofh;
 extern INT32 Sf2thndr;
 extern INT32 Pzloop2;
-extern INT32 Mmatrix;
 extern INT32 Sfa2ObjHack;
 extern INT32 Ssf2tb;
 extern INT32 Dinohunt;

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -8460,13 +8460,6 @@ STD_ROM_FN(Xmvsfur2)
 
 // Driver functions
 
-static INT32 MmatrixInit()
-{
-	Mmatrix = 1;
-	
-	return Cps2Init();
-}
-
 static INT32 MvscjsingInit()
 {
 	// The case has a volume knob, and the digital switches are missing and the slider is missing from the test screen
@@ -8537,7 +8530,6 @@ static INT32 DrvExit()
 	Ssf2t = 0;
 	Ssf2tb = 0;
 	Xmcota = 0;
-	Mmatrix = 0;
 
 	Cps2Volume = 39;
 	Cps2DisableDigitalVolume = 0;
@@ -9510,7 +9502,7 @@ struct BurnDriver BurnDrvCpsMarsMatrix = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VERSHOOT, 0,
 	NULL, MmatrixRomInfo, MmatrixRomName, NULL, NULL, NULL, NULL, MmatrixInputInfo, NULL,
-	MmatrixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
@@ -9520,7 +9512,7 @@ struct BurnDriver BurnDrvCpsMarsMatrixJ = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VERSHOOT, 0,
 	NULL, MmatrixjRomInfo, MmatrixjRomName, NULL, NULL, NULL, NULL, MmatrixInputInfo, NULL,
-	MmatrixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
@@ -12639,13 +12631,6 @@ static INT32 PhoenixInit()
 	return nRet;
 }
 
-static INT32 MmatrixPhoenixInit()
-{
-	Mmatrix = 1;
-	
-	return PhoenixInit();
-}
-
 static INT32 Ssf2PhoenixInit()
 {
 	INT32 nRet = PhoenixInit();
@@ -12871,7 +12856,7 @@ struct BurnDriver BurnDrvCpsMarsMatrixd = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VERSHOOT, 0,
 	NULL, MmatrixdRomInfo, MmatrixdRomName, NULL, NULL, NULL, NULL, MmatrixInputInfo, NULL,
-	MmatrixPhoenixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	PhoenixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 

--- a/src/burn/drv/capcom/qs_c.cpp
+++ b/src/burn/drv/capcom/qs_c.cpp
@@ -19,10 +19,6 @@ static const INT32 nQscClock = 60000000;
 static const INT32 nQscClockDivider = 2496;
 
 static INT32 nQscRate = 0;
-INT32 Mmatrix; // global
-
-static INT32 Tams = -1;
-static INT32* Qs_s = NULL;
 
 static INT32 nPos;
 static INT32 nDelta;
@@ -109,7 +105,7 @@ struct qsound_chip {
 };
 
 static UINT16 *register_map[256];
-INT16 pan_tables[2][2][98];
+static INT16 pan_tables[2][2][98];
 
 static INT16 interpolate_buffer[2][4];
 
@@ -743,9 +739,6 @@ void QscReset()
 void QscExit()
 {
 	nQscRate = 0;
-
-	BurnFree(Qs_s);
-	Tams = -1;
 }
 
 INT32 QscInit(INT32 nRate)
@@ -889,12 +882,12 @@ INT32 QscUpdate(INT32 nEnd)
 			nDelta -= 0x1000;
 		}
 
-		nLeftOut = INTERPOLATE4PS_16BIT((nDelta >> 2),
+		nLeftOut = INTERPOLATE4PS_16BIT(nDelta,
 								  interpolate_buffer[0][0],
 								  interpolate_buffer[0][1],
 								  interpolate_buffer[0][2],
 								  interpolate_buffer[0][3]);
-		nRightOut = INTERPOLATE4PS_16BIT((nDelta >> 2),
+		nRightOut = INTERPOLATE4PS_16BIT(nDelta,
 								  interpolate_buffer[1][0],
 								  interpolate_buffer[1][1],
 								  interpolate_buffer[1][2],


### PR DESCRIPTION
Followup to my previous PR.

Remove unused variables
Remove remnants of the Mars Matrix stereo hack.
Fix noise during the 4-tap interpolation