### PR TITLE
All I wanted to do was clean up the todo against hcastle...

### DIFF
--- a/projectfiles/visualstudio-2019/fba_vs2010.vcxproj
+++ b/projectfiles/visualstudio-2019/fba_vs2010.vcxproj
@@ -1583,6 +1583,8 @@ del build_details.exe
     <IncludePath>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;..\..\src\dep\vc\include;$(IncludePath)</IncludePath>
     <IntDir>$(SolutionDir)$(Configuration)\</IntDir>
     <LibraryPath>$(LibraryPath)</LibraryPath>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;..\..\src\dep\vc\include;$(IncludePath)</IncludePath>
@@ -1601,6 +1603,7 @@ del build_details.exe
       <AdditionalIncludeDirectories>..\..\src\dep\libs\lib7z;..\..\src\burner\win32\resource;..\..\src\burn\drv\taito;..\..\src\burn\drv\misc_post90s;..\..\src\burn\devices;generated;..\..\src\intf\audio\win32;..\..\src\intf\audio;..\..\src\intf\;..\..\src\intf\video\scalers;..\..\src\intf\video\win32;..\..\src\intf\video;..\..\src\intf\perfcount\win32;..\..\src\intf\perfcount;..\..\src\intf\input\win32;..\..\src\intf\input;..\..\src\intf\cd\win32;..\..\src\intf\cd;..\..\src\intf;..\..\src\burner\win32;..\..\src\dep\libs\zlib;..\..\src\dep\libs\libpng;..\..\src\dep\libs;..\..\src\dep\kaillera\client;..\..\src\dep\kaillera;..\..\src\burn\snd;..\..\src\cpu;..\..\src\burner;..\..\src\burn;..\..\src\cpu\z80;..\..\src\cpu\sh2;..\..\src\cpu\s2650;..\..\src\cpu\nec;..\..\src\cpu\m6809;..\..\src\cpu\m6805;..\..\src\cpu\m6800;..\..\src\cpu\m6502;..\..\src\cpu\m68k;..\..\src\cpu\i8039;..\..\src\cpu\konami;..\..\src\cpu\hd6309;..\..\src\cpu\h6280;..\..\src\cpu\arm7;..\..\src\cpu\arm;..\..\src\cpu\g65816;..\..\src\cpu\spc700;..\..\src\cpu\i8051;..\..\src\cpu\tms32010;..\..\src\cpu\tms34010;..\..\src\cpu\i8x41;..\..\src\burn\drv\sega;..\..\src\burn\drv\dataeast;..\..\src\burn\drv\konami;..\..\src\cpu\z180;..\..\src\burn\drv\irem;..\..\src\cpu\upd7810;..\..\src\cpu\v60;..\..\src\cpu\upd7725;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAs>Default</CompileAs>
       <PreprocessorDefinitions>BUILD_WIN32;FASTCALL;_DEBUG;FBA_DEBUG;LSB_FIRST;INLINE=__inline static;INCLUDE_LIB_PNGH;C_INLINE=__inline;MAME_INLINE=__inline static;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/burn/burn.cpp
+++ b/src/burn/burn.cpp
@@ -791,13 +791,13 @@ INT32 BurnUpdateProgress(double fProgress, const TCHAR* pszText, bool bAbs)
 }
 
 // ----------------------------------------------------------------------------
-
+// NOTE: Make sure this is called before any sound emulation!!
 INT32 BurnSetRefreshRate(double dFrameRate)
 {
 	if (!bForce60Hz) {
 		nBurnFPS = (INT32)(100.0 * dFrameRate);
 	}
-
+	nBurnSoundLen = nBurnSoundRate / (nBurnFPS / 100.0000);
 	return 0;
 }
 

--- a/src/burn/devices/avgdvg.cpp
+++ b/src/burn/devices/avgdvg.cpp
@@ -384,6 +384,8 @@ static INT32 dvg_generate_vector_list(void)
 	INT32 x, y, z, temp, a;
 	INT32 deltax, deltay;
 
+	memset(stack, 0, sizeof(stack));
+
 	/* reset the vector list */
 	vector_reset();
 

--- a/src/burn/drv/dataeast/d_dec8.cpp
+++ b/src/burn/drv/dataeast/d_dec8.cpp
@@ -1303,6 +1303,8 @@ static void Deco222Decode()
 
 static INT32 DrvInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -1404,8 +1406,6 @@ static INT32 DrvInit()
 
 	realMCU = 1;
 	DrvMCUInit();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM3812Init(1, 3000000, &DrvYM3812FMIRQHandler, 0);
 	BurnTimerAttachYM3812(&M6502Config, 1500000);
@@ -2196,6 +2196,8 @@ static INT32 CobraGfxDecode()
 
 static INT32 CobraInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -2307,8 +2309,6 @@ static INT32 CobraInit()
 	M6502SetReadHandler(ghostb_sound_read);
 	M6502SetWriteHandler(ghostb_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM2203Init(1, 1500000, NULL, 0);
 	BurnTimerAttachM6809(2000000);
@@ -2917,6 +2917,8 @@ static INT32 SrdarwinGfxDecode()
 
 static INT32 SrdarwinInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -2980,8 +2982,6 @@ static INT32 SrdarwinInit()
 	M6502SetReadHandler(ghostb_sound_read);
 	M6502SetWriteHandler(ghostb_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM2203Init(1, 1500000, NULL, 0);
 	BurnTimerAttachM6809(2000000);
@@ -3544,6 +3544,8 @@ static INT32 GondoGfxDecode()
 
 static INT32 GondoInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -3660,8 +3662,6 @@ static INT32 GondoInit()
 	M6502SetReadHandler(ghostb_sound_read);
 	M6502SetWriteHandler(gondo_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM3526Init(3000000, &DrvYM3812FMIRQHandler, 0);
 	BurnTimerAttachYM3526(&M6502Config, 1500000);
@@ -4216,6 +4216,8 @@ static INT32 OscarGfxDecode()
 
 static INT32 OscarInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -4277,8 +4279,6 @@ static INT32 OscarInit()
 	M6502SetReadHandler(ghostb_sound_read);
 	M6502SetWriteHandler(gondo_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM3526Init(3000000, &DrvYM3812FMIRQHandler, 0);
 	BurnTimerAttachYM3526(&M6502Config, 1500000);
@@ -4820,6 +4820,8 @@ static INT32 LastmissGfxDecode()
 
 static INT32 LastmissInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -4919,8 +4921,6 @@ static INT32 LastmissInit()
 	M6502SetReadHandler(ghostb_sound_read);
 	M6502SetWriteHandler(gondo_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM3526Init(3000000, &DrvYM3812FMIRQHandler, 0);
 	BurnTimerAttachYM3526(&M6502Config, 1500000);
@@ -5625,6 +5625,8 @@ static INT32 CsilverDoReset()
 
 static INT32 CsilverInit()
 {
+	BurnSetRefreshRate(58.00);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -5693,8 +5695,6 @@ static INT32 CsilverInit()
 	M6502SetReadHandler(csilver_sound_read);
 	M6502SetWriteHandler(csilver_sound_write);
 	M6502Close();
-
-	BurnSetRefreshRate(58.00);
 
 	BurnYM3526Init(3000000, &DrvYM3812FMIRQHandler, 0);
 	BurnTimerAttachYM3526(&M6502Config, 1500000);

--- a/src/burn/drv/irem/d_vigilant.cpp
+++ b/src/burn/drv/irem/d_vigilant.cpp
@@ -1467,6 +1467,8 @@ static INT32 DrvInit()
 {
 	INT32 nRet = 0, nLen;
 
+	BurnSetRefreshRate(55.0);
+
 	// Allocate and Blank all required memory
 	Mem = NULL;
 	MemIndex();
@@ -1552,8 +1554,7 @@ static INT32 DrvInit()
 	ZetMapArea(0xf000, 0xffff, 1, DrvZ80Ram2             );
 	ZetMapArea(0xf000, 0xffff, 2, DrvZ80Ram2             );
 	ZetClose();
-	
-	BurnSetRefreshRate(55.0);
+
 	nCyclesTotal[0] = 3579645 / 55;
 	nCyclesTotal[1] = 3579645 / 55;
 	
@@ -1573,6 +1574,8 @@ static INT32 DrvInit()
 static INT32 DrvcInit()
 {
 	INT32 nRet = 0, nLen;
+
+	BurnSetRefreshRate(55.0);
 
 	// Allocate and Blank all required memory
 	Mem = NULL;
@@ -1659,7 +1662,6 @@ static INT32 DrvcInit()
 	ZetMapArea(0xf000, 0xffff, 2, DrvZ80Ram2             );
 	ZetClose();
 	
-	BurnSetRefreshRate(55.0);
 	nCyclesTotal[0] = 3579645 / 55;
 	nCyclesTotal[1] = 3579645 / 55;
 	
@@ -1679,6 +1681,8 @@ static INT32 DrvcInit()
 static INT32 DrvbInit()
 {
 	INT32 nRet = 0, nLen;
+
+	BurnSetRefreshRate(55.0);
 
 	// Allocate and Blank all required memory
 	Mem = NULL;
@@ -1760,7 +1764,6 @@ static INT32 DrvbInit()
 	ZetMapArea(0xf000, 0xffff, 2, DrvZ80Ram2             );
 	ZetClose();
 	
-	BurnSetRefreshRate(55.0);
 	nCyclesTotal[0] = 3579645 / 55;
 	nCyclesTotal[1] = 3579645 / 55;
 	
@@ -1780,6 +1783,8 @@ static INT32 DrvbInit()
 static INT32 BuccanrsInit()
 {
 	INT32 nRet = 0, nLen;
+
+	BurnSetRefreshRate(55.0);
 
 	// Allocate and Blank all required memory
 	Mem = NULL;
@@ -1859,7 +1864,6 @@ static INT32 BuccanrsInit()
 	ZetMapArea(0xf000, 0xffff, 2, DrvZ80Ram2             );
 	ZetClose();
 	
-	BurnSetRefreshRate(55.0);
 	nCyclesTotal[0] = 5688800 / 55;
 	nCyclesTotal[1] = (18432000 / 6) / 55;
 	
@@ -1888,6 +1892,7 @@ static INT32 BuccanrsInit()
 static INT32 KikcubicInit()
 {
 	INT32 nRet = 0, nLen;
+	BurnSetRefreshRate(55.0);
 
 	// Allocate and Blank all required memory
 	Mem = NULL;
@@ -1991,7 +1996,6 @@ static INT32 KikcubicInit()
 	ZetMapArea(0xf000, 0xffff, 2, DrvZ80Ram2             );
 	ZetClose();
 	
-	BurnSetRefreshRate(55.0);
 	nCyclesTotal[0] = 3579645 / 55;
 	nCyclesTotal[1] = 3579645 / 55;
 	

--- a/src/burn/drv/konami/d_hcastle.cpp
+++ b/src/burn/drv/konami/d_hcastle.cpp
@@ -1,7 +1,6 @@
 // FB Alpha Haunted Castle / Akuma-Jou Dracula driver module
 // Based on MAME driver by Bryan McPhail
 //
-// Todo: figure out crash on game-exit when refresh rate is set @ 59 in DrvInit()
 
 #include "tiles_generic.h"
 #include "z80_intf.h"

--- a/src/burn/drv/konami/d_hcastle.cpp
+++ b/src/burn/drv/konami/d_hcastle.cpp
@@ -441,6 +441,8 @@ static void DrvPaletteInit()
 
 static INT32 DrvInit()
 {
+	BurnSetRefreshRate(59);
+
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -511,8 +513,6 @@ static INT32 DrvInit()
 
 	K051649Init(3579545/2);
 	K051649SetRoute(0.45, BURN_SND_ROUTE_BOTH);
-
-	//BurnSetRefreshRate(59);  Causes crash-on-exit.  weird? hmm.
 
 	GenericTilesInit();
 

--- a/src/burn/drv/konami/d_yiear.cpp
+++ b/src/burn/drv/konami/d_yiear.cpp
@@ -304,7 +304,7 @@ static void DrvPaletteInit()
 
 static INT32 DrvInit()
 {
-//	BurnSetRefreshRate(60.58);
+	BurnSetRefreshRate(60.58);
 
 	AllMem = NULL;
 	MemIndex();

--- a/src/burn/drv/megadrive/megadrive.cpp
+++ b/src/burn/drv/megadrive/megadrive.cpp
@@ -1456,6 +1456,7 @@ static INT32 MegadriveResetDo()
 	MegadriveCheckHardware();
 
 	if (Hardware & 0x40) {
+
 		BurnSetRefreshRate(50.0);
 		Reinitialise();
 

--- a/src/burn/drv/midway/midtunit.cpp
+++ b/src/burn/drv/midway/midtunit.cpp
@@ -940,7 +940,9 @@ static void JdreddpProtWrite(UINT32 address, UINT16 value)
 // init, exit, etc.
 INT32 TUnitInit()
 {
-    nSoundType = SOUND_ADPCM;
+	BurnSetRefreshRate(54.71);
+
+	nSoundType = SOUND_ADPCM;
 	bGfxRomLarge = false;
 
 	MemIndex();
@@ -981,8 +983,6 @@ INT32 TUnitInit()
 
     nRet = LoadGfxBanks();
     if (nRet != 0) return 1;
-	
-	BurnSetRefreshRate(54.71);
 
     TMS34010MapReset();
     TMS34010Init();

--- a/src/burn/drv/midway/midwunit.cpp
+++ b/src/burn/drv/midway/midwunit.cpp
@@ -384,6 +384,8 @@ static void WolfDoReset()
 
 INT32 WolfUnitInit()
 {
+	BurnSetRefreshRate(54.71);
+
     MemIndex();
     INT32 nLen = MemEnd - (UINT8 *)0;
 
@@ -467,8 +469,6 @@ INT32 WolfUnitInit()
 	Dcs2kResetWrite(0);
 
 	GenericTilesInit();
-	
-	BurnSetRefreshRate(54.71);
 	
 	WolfDoReset();
 	

--- a/src/burn/drv/pre90s/d_ddragon.cpp
+++ b/src/burn/drv/pre90s/d_ddragon.cpp
@@ -2101,6 +2101,8 @@ static INT32 DrvMachineInit()
 
 static INT32 Drv2MachineInit()
 {
+	BurnSetRefreshRate(57.444853);
+
 	// Setup the HD6309 emulation
 	HD6309Init(0);
 	HD6309Open(0);
@@ -2143,8 +2145,6 @@ static INT32 Drv2MachineInit()
 
 	MSM6295Init(0, 1056000 / 132, 1);
 	MSM6295SetRoute(0, 0.20, BURN_SND_ROUTE_BOTH);
-
-	BurnSetRefreshRate(57.444853);
 
 	nCyclesTotal[0] = (INT32)((double)3000000 / 57.44853);
 	nCyclesTotal[1] = (INT32)((double)4000000 / 57.44853);

--- a/src/burn/drv/pre90s/d_mitchell.cpp
+++ b/src/burn/drv/pre90s/d_mitchell.cpp
@@ -1945,7 +1945,7 @@ static INT32 DokabenInit()
 static INT32 PangInit()
 {
 	INT32 nRet = 0, nLen;
-	
+	BurnSetRefreshRate(57);
 	Mem = NULL;
 	PangMemIndex();
 	nLen = MemEnd - (UINT8 *)0;
@@ -1977,7 +1977,7 @@ static INT32 PangInit()
 	pang_decode();
 	
 	MitchellMachineInit();
-	BurnSetRefreshRate(57);
+
 	DrvDoReset();
 
 	return 0;

--- a/src/burn/drv/pre90s/d_namcos1.cpp
+++ b/src/burn/drv/pre90s/d_namcos1.cpp
@@ -1564,7 +1564,7 @@ static INT32 Namcos1GetRoms()
 
 static INT32 DrvInit()
 {
-	//BurnSetRefreshRate((sixtyhz) ? 60.00 : 60.6060); above 60hz is a no-go, causes horrible sound issues on some systems (ym2151)
+	BurnSetRefreshRate((sixtyhz) ? 60.00 : 60.6060); // above 60hz is a no-go, causes horrible sound issues on some systems (ym2151)
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;

--- a/src/burn/drv/pre90s/d_psychic5.cpp
+++ b/src/burn/drv/pre90s/d_psychic5.cpp
@@ -525,6 +525,8 @@ static INT32 DrvInit()
 {
 	INT32 nRet = 0, nLen;
 
+	BurnSetRefreshRate(54);
+
 	// Allocate and Blank all required memory
 	Mem = NULL;
 	MemIndex();
@@ -596,8 +598,6 @@ static INT32 DrvInit()
 	BurnYM2203SetRoute(1, BURN_SND_YM2203_AY8910_ROUTE_3, 0.08, BURN_SND_ROUTE_BOTH);
 
 	GenericTilesInit();
-	
-	BurnSetRefreshRate(54);
 
 	// Reset the driver
 	DrvDoReset();

--- a/src/burn/drv/pre90s/d_scregg.cpp
+++ b/src/burn/drv/pre90s/d_scregg.cpp
@@ -388,6 +388,7 @@ static INT32 MemIndex()
 
 static INT32 DrvInit(void (*m6502Init)(), INT32 (*pLoadCB)())
 {
+	BurnSetRefreshRate(57);
 	AllMem = NULL;
 	MemIndex();
 	INT32 nLen = MemEnd - (UINT8 *)0;
@@ -405,8 +406,6 @@ static INT32 DrvInit(void (*m6502Init)(), INT32 (*pLoadCB)())
 	if (m6502Init) {
 		m6502Init();
 	}
-
-	BurnSetRefreshRate(57);
 
 	AY8910Init(0, 1500000, 0);
 	AY8910Init(1, 1500000, 1);

--- a/src/burn/drv/pst90s/d_kaneko16.cpp
+++ b/src/burn/drv/pst90s/d_kaneko16.cpp
@@ -4743,7 +4743,9 @@ static INT32 BlazeonInit()
 static INT32 WingforcInit()
 {
 	INT32 nRet = 0, nLen;
-
+	
+	BurnSetRefreshRate(59.1854); // hmm, this causes clicks in audio. let's just give it the cycles/per frame it wants instead. (see WingforcFrame())
+	
 	Kaneko16NumSprites = 0x4000;
 	Kaneko16NumTiles = 0x4000;
 	Kaneko16NumTiles2 = 0;
@@ -4834,8 +4836,6 @@ static INT32 WingforcInit()
 	ZetSetInHandler(Kaneko16Z80PortRead);
 	ZetSetOutHandler(Kaneko16Z80PortWrite);
 	ZetClose();
-
-//	BurnSetRefreshRate(59.1854); // hmm, this causes clicks in audio. let's just give it the cycles/per frame it wants instead. (see WingforcFrame())
 
 	// Setup the YM2151 emulation
 	BurnYM2151Init(4000000);
@@ -7214,8 +7214,11 @@ static INT32 WingforcFrame()
 	Kaneko16MakeInputs();
 
 	INT32 nInterleave = 256;
-	nCyclesTotal[0] = ((UINT64)16000000 * (UINT64)10000) / 591854;
-	nCyclesTotal[1] = ((UINT64)4000000 * (UINT64)10000) / 591854;
+	nCyclesTotal[0] = 12000000 / 59.1854;
+	nCyclesTotal[1] = 4000000 / 59.1854;
+
+	//nCyclesTotal[0] = ((UINT64)16000000 * (UINT64)10000) / 591854;
+	//nCyclesTotal[1] = ((UINT64)4000000 * (UINT64)10000) / 591854;
 	nCyclesDone[0] = nCyclesDone[1] = 0;
 	nSoundBufferPos = 0;
 

--- a/src/burn/drv/pst90s/d_powerins.cpp
+++ b/src/burn/drv/pst90s/d_powerins.cpp
@@ -789,11 +789,11 @@ static INT32 powerinsInit()
 	}
 
 	if (game_drv == GAME_POWERINS) {
+		BurnSetRefreshRate(56.0);
 		BurnYM2203Init(1, 12000000 / 8, &powerinsIRQHandler, 0);
 		BurnTimerAttachZet(6000000);
 		BurnYM2203SetAllRoutes(0, 2.00, BURN_SND_ROUTE_BOTH);
-		BurnSetRefreshRate(56.0);
-
+		
 		MSM6295Init(0, 4000000 / 165, 1);
 		MSM6295Init(1, 4000000 / 165, 1);
 		MSM6295SetRoute(0, 0.15, BURN_SND_ROUTE_BOTH);

--- a/src/burn/drv/pst90s/d_tumbleb.cpp
+++ b/src/burn/drv/pst90s/d_tumbleb.cpp
@@ -3057,7 +3057,8 @@ static void SemicomYM2151IrqHandler(INT32 Irq)
 static INT32 DrvInit(bool bReset, INT32 SpriteRamSize, INT32 SpriteMask, INT32 SpriteXOffset, INT32 SpriteYOffset, INT32 NumSprites, INT32 NumChars, INT32 NumTiles, double Refresh, INT32 OkiFreq)
 {
 	INT32 nRet = 0, nLen;
-	
+	BurnSetRefreshRate(Refresh);
+
 	DrvSpriteRamSize = SpriteRamSize;
 	DrvNumSprites = NumSprites,
 	DrvNumChars = NumChars,
@@ -3098,7 +3099,7 @@ static INT32 DrvInit(bool bReset, INT32 SpriteRamSize, INT32 SpriteMask, INT32 S
 		MSM6295SetRoute(0, 0.70, BURN_SND_ROUTE_BOTH);
 	}
 	
-	BurnSetRefreshRate(Refresh);
+
 	
 	nCyclesTotal[0] = 14000000 / 60;
 	
@@ -3473,7 +3474,9 @@ inline static INT32 JumppopSynchroniseStream(INT32 nSoundRate)
 static INT32 JumppopInit()
 {
 	INT32 nRet = 0, nLen;
-	
+
+	BurnSetRefreshRate(60.0);
+
 	DrvSpriteRamSize = 0x1000;
 	DrvNumSprites = 0x4000,
 	DrvNumChars = 0x8000,
@@ -3580,8 +3583,6 @@ static INT32 JumppopInit()
 	// Setup the OKIM6295 emulation
 	MSM6295Init(0, 875000 / 132, 1);
 	MSM6295SetRoute(0, 0.50, BURN_SND_ROUTE_BOTH);
-	
-	BurnSetRefreshRate(60.0);
 	
 	nCyclesTotal[0] = 16000000 / 60;
 	nCyclesTotal[1] = 3500000 / 60;

--- a/src/burn/drv/spectrum/d_spectrum.cpp
+++ b/src/burn/drv/spectrum/d_spectrum.cpp
@@ -620,6 +620,8 @@ static INT32 SpectrumInit(INT32 nSnapshotType)
 	
 	INT32 nRet = 0, nLen;
 	
+	BurnSetRefreshRate(50.0);
+
 	Mem = NULL;
 	MemIndex();
 	nLen = MemEnd - (UINT8 *)0;
@@ -649,8 +651,6 @@ static INT32 SpectrumInit(INT32 nSnapshotType)
 	
 	DACInit(0, 0, 0, ZetTotalCycles, 3500000);
 	DACSetRoute(0, 0.50, BURN_SND_ROUTE_BOTH);
-	
-	BurnSetRefreshRate(50.0);
 
 	GenericTilesInit();
 	
@@ -704,13 +704,13 @@ static INT32 Spectrum128Init(INT32 nSnapshotType)
 	ZetMapArea(0x8000, 0xbfff, 2, SpecZ80Ram + (2 << 14) );
 	ZetClose();
 	
+	BurnSetRefreshRate(50.0);
+
 	DACInit(0, 0, 0, ZetTotalCycles, 3500000);
 	DACSetRoute(0, 0.50, BURN_SND_ROUTE_BOTH);
 	
 	AY8910Init(0, 17734475 / 10, 0);
 	AY8910SetAllRoutes(0, 0.25, BURN_SND_ROUTE_BOTH);
-	
-	BurnSetRefreshRate(50.0);
 
 	GenericTilesInit();
 	


### PR DESCRIPTION
I had a look to see why hcastle was crashing when using the correct refresh rate. It turns out that nBurnSoundLen is not calculated correctly until after DrvInit if a game is not using 60hz. This probably affects a lot of games and possibly might need further verifcation on others to make sure that the sound is working correctly now it's calculated correctly. Some sound cores didn't care about nBurnSoundLen when creating their internal buffers but that ones that do would always have a buffer underrun.

I also think I have found a fix for starwars crashing randonmly on my machine but if someone could verify that the games still work on other machines that would be good ;)

Some notes:
Wingforc - someone should check that the changes I made are correct :)
hcastle - seems ok with the refresh rate now
yiear - might be ok as is now I have renabled the refrest rate. Might not be. Could someone check.
namcos1 - Seems the games that are above 60hz now work with the correct refresh but someone should double check

Remaining refrest problems I know of:
metlclsh - Had a note that it locks up with refrest rate, seems to still crash so I have left it uncommented
M62 - Wasn't sure if the refrest rate was commented out due to sound so have left this